### PR TITLE
Constrain matplotlib version because of pyeddytracker

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -29,7 +29,7 @@ dependencies:
   - jupyterlab
   - jupytext
   - libnetcdf>=4.9.2
-  - matplotlib
+  - matplotlib<3.8  # because of pyeddytracker
   - nco
   - netcdf4
   - numba<0.56


### PR DESCRIPTION
This MR constraints `matplotlib<3.8` for the hackathon python environment.

This is due to a [bug in pyeddytracker](https://matplotlib.org/3.8.2/api/prev_api_changes/api_changes_3.8.0.html#contourset-is-now-a-single-collection) that was caused by an [API change in Matplotlib 3.8](https://github.com/AntSimi/py-eddy-tracker/issues/217).